### PR TITLE
Add memory and memory swap flags to `rpi-duckiebot-lanefollowing-demo`

### DIFF
--- a/book/software_devel/99_docker/02_getting_started.md
+++ b/book/software_devel/99_docker/02_getting_started.md
@@ -196,6 +196,7 @@ After the Duckiebot has been calibrated, you can now launch the [Lane Following 
 
 
     $ docker -H ![DUCKIEBOT_NAME].local run -it --name lanefollowing-demo \
+      --memory="200m" --memory-swap="1g" \
       --privileged \
       -v /data:/data \
       --net host \


### PR DESCRIPTION
As prescribed in https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details